### PR TITLE
Change create password history only for changed passwords

### DIFF
--- a/src/EventListener/PasswordEntityListener.php
+++ b/src/EventListener/PasswordEntityListener.php
@@ -86,21 +86,6 @@ class PasswordEntityListener
 
             }
         }
-
-        foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            $entityHash = spl_object_hash($entity);
-
-            // Make sure to process it only once. We experienced cases when this can be called multiple times.
-            if (array_key_exists($entityHash, $this->processedNewEntities)) {
-                continue;
-            }
-
-            if (is_a($entity, $this->entityClass, true) && $entity instanceof HasPasswordPolicyInterface) {
-                // Explicitly check if the there is no value for password
-                $this->createPasswordHistory($em, $entity, $entity->getPassword());
-                $this->processedNewEntities[$entityHash] = true;
-            }
-        }
     }
 
     /**

--- a/tests/Unit/EventListener/PasswordEntityListenerTest.php
+++ b/tests/Unit/EventListener/PasswordEntityListenerTest.php
@@ -65,10 +65,6 @@ class PasswordEntityListenerTest extends UnitTestCase
      */
     public function testOnFlushUpdates()
     {
-        $this->uowMock->shouldReceive('getScheduledEntityInsertions')
-                      ->once()
-                      ->andReturn([]);
-
         $this->uowMock->shouldReceive('getScheduledEntityUpdates')
                       ->once()
                       ->andReturn([
@@ -87,39 +83,6 @@ class PasswordEntityListenerTest extends UnitTestCase
         $this->passwordEntityListener->shouldReceive('createPasswordHistory')
                                      ->once()
                                      ->withArgs([$this->emMock, $this->entityMock, 'pwd_1']);
-
-        $this->emMock->shouldReceive('getUnitOfWork')
-                     ->andReturn($this->uowMock);
-
-        $event = new OnFlushEventArgs($this->emMock);
-
-        $this->passwordEntityListener->onFlush($event);
-
-        $this->assertTrue(true);
-    }
-
-    public function testOnFlushInserts()
-    {
-        $this->entityMock->shouldReceive('getPassword')
-                         ->andReturn('pwd');
-        $this->entityMock->shouldReceive('getPasswordChangedAt')
-                         ->andReturnNull();
-
-        $this->uowMock->shouldReceive('getScheduledEntityInsertions')
-                      ->once()
-                      ->andReturn([
-                          $this->entityMock,
-                      ]);
-
-        $this->uowMock->shouldReceive('getScheduledEntityUpdates')
-                      ->once()
-                      ->andReturn([]);
-
-        $this->uowMock->shouldNotReceive('getEntityChangeSet');
-
-        $this->passwordEntityListener->shouldReceive('createPasswordHistory')
-                                     ->once()
-                                     ->withArgs([$this->emMock, $this->entityMock, 'pwd']);
 
         $this->emMock->shouldReceive('getUnitOfWork')
                      ->andReturn($this->uowMock);


### PR DESCRIPTION
Remove keeping first password to be consistent and keep only "old" passwords. Currently when user is created it keeps its "new" password on on change keeps the same password again.